### PR TITLE
Disabling nightly-build cron job until build is fixed

### DIFF
--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -1,14 +1,14 @@
 # This workflow will build the extension against the latest Liquibase artifact
-name: "Nightly build"
-
-on:
-    workflow_dispatch:
-    schedule:
-        - cron: '0 7 * * 1-5'
-
-jobs:
-    nightly-build:
-        uses: liquibase/build-logic/.github/workflows/os-extension-test.yml@v0.6.4
-        with:
-            nightly: true
-        secrets: inherit
+#name: "Nightly build"
+#
+#on:
+#    workflow_dispatch:
+#    schedule:
+#        - cron: '0 7 * * 1-5'
+#
+#jobs:
+#    nightly-build:
+#        uses: liquibase/build-logic/.github/workflows/os-extension-test.yml@v0.6.4
+#        with:
+#            nightly: true
+#        secrets: inherit


### PR DESCRIPTION
Couchbase build is still broken ([build execution example](https://github.com/liquibase/liquibase-couchbase/actions/runs/8338870395/job/22819915870)), so we have decided to disabled cron build job for now, until failing tests gets fixed.

