### PR TITLE
🔧 update actions/upload-artifact version to v4

### DIFF
--- a/.github/workflows/os-extension-test.yml
+++ b/.github/workflows/os-extension-test.yml
@@ -30,13 +30,13 @@ jobs:
               run: echo "::set-output name=artifact_id::$(mvn --file liquibase-couchbase/pom.xml help:evaluate -Dexpression=project.artifactId -q -DforceStdout)"
 
             - name: Save Artifacts
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@v4
               with:
                   name: ${{ steps.get-artifact-id.outputs.artifact_id }}-artifacts
                   path: liquibase-couchbase/target/*
 
             - name: Save Event File
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@v4
               with:
                   name: Event File
                   path: ${{ github.event_path }}
@@ -63,7 +63,7 @@ jobs:
                   distribution: 'temurin'
                   cache: 'maven'
 
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                   name: ${{needs.build.outputs.artifact_id}}-artifacts
                   path: liquibase-couchbase/target
@@ -73,7 +73,7 @@ jobs:
 
             - name: Archive Test Results - ${{ matrix.os }}
               if: ${{ always() }}
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@v4
               with:
                   name: test-reports-jdk-${{ matrix.java }}-${{ matrix.os }}
                   path: |
@@ -100,7 +100,7 @@ jobs:
                   distribution: 'temurin'
                   cache: 'maven'
 
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                   name: ${{needs.build.outputs.artifact_id}}-artifacts
                   path: liquibase-couchbase/target
@@ -110,7 +110,7 @@ jobs:
 
             - name: Archive Test Results - ${{ matrix.os }}
               if: ${{ always() }}
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@v4
               with:
                   name: test-reports-jdk-${{ matrix.java }}-${{ matrix.os }}
                   path: |


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflow configuration in the `.github/workflows/os-extension-test.yml` file. The primary change is upgrading the version of the `actions/upload-artifact` and `actions/download-artifact` actions from v3 to v4.

Changes in `.github/workflows/os-extension-test.yml`:

* Updated `actions/upload-artifact` to version 4 in multiple steps. [[1]](diffhunk://#diff-43ea773ed34788e59031ecce17de6fe3c738530fa5aaaab22805ebf12ab58001L33-R39) [[2]](diffhunk://#diff-43ea773ed34788e59031ecce17de6fe3c738530fa5aaaab22805ebf12ab58001L76-R76) [[3]](diffhunk://#diff-43ea773ed34788e59031ecce17de6fe3c738530fa5aaaab22805ebf12ab58001L113-R113)
* Updated `actions/download-artifact` to version 4 in multiple steps. [[1]](diffhunk://#diff-43ea773ed34788e59031ecce17de6fe3c738530fa5aaaab22805ebf12ab58001L66-R66) [[2]](diffhunk://#diff-43ea773ed34788e59031ecce17de6fe3c738530fa5aaaab22805ebf12ab58001L103-R103)