### PR TITLE
DAT-21010: Add Java 25 to github builds

### DIFF
--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -11,6 +11,6 @@
  #   uses: liquibase/build-logic/.github/workflows/os-extension-test.yml@main
   #  with:
       #nightly: true
-      #java: "[ 17, 21 ]"
+      #java: "[ 17, 21, 25 ]"
     #secrets: inherit
     

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
         uses: liquibase/build-logic/.github/workflows/os-extension-test.yml@main
         secrets: inherit
         with:
-            java: "[ 17, 21 ]"
+            java: "[ 17, 21, 25 ]"
 
     dependabot:
         needs: build-test


### PR DESCRIPTION
This PR adds Java 25 to the matrix configuration for Java version testing in GitHub Actions workflows.

## Changes
- Updated workflow files to include Java 25 in the matrix strategy
- Ensures compatibility testing with Java 25 alongside existing versions (11, 17, 21)

## Related
- Jira Ticket: [DAT-21010](https://datical.atlassian.net/browse/DAT-21010)

🤖 Generated with [Claude Code](https://claude.com/claude-code)